### PR TITLE
WIP getting rabbitmq Dockerfile to build again

### DIFF
--- a/rabbitmq-server/Dockerfile
+++ b/rabbitmq-server/Dockerfile
@@ -1,5 +1,6 @@
 # https://github.com/docker-library/rabbitmq/blob/1a37166704d2ca7c386980387e81615985d5db47/3.7/debian/Dockerfile
-FROM debian:stretch-slim
+FROM debian:buster-slim 
+
 
 RUN set -eux; \
 	apt-get update; \
@@ -40,26 +41,7 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove $fetchDeps
 
-# RabbitMQ 3.6.15+ requires Erlang 19.3+ (and Stretch only has 19.2); https://www.rabbitmq.com/which-erlang.html
-# so we'll pull Erlang from Buster instead (not using Erlang Solutions since their multiarch support is extremely limited)
-RUN set -eux; \
-# add buster sources.list
-	sed 's/stretch/buster/g' /etc/apt/sources.list \
-		| tee /etc/apt/sources.list.d/buster.list; \
-# update apt-preferences such that we get only erlang* from buster (and erlang* only from buster)
-	{ \
-		echo 'Package: *'; \
-		echo 'Pin: release n=buster*'; \
-		echo 'Pin-Priority: -10'; \
-		echo; \
-		echo 'Package: erlang*'; \
-		echo 'Pin: release n=buster*'; \
-		echo 'Pin-Priority: 999'; \
-		echo; \
-		echo 'Package: erlang*'; \
-		echo 'Pin: release n=stretch*'; \
-		echo 'Pin-Priority: -10'; \
-	} | tee /etc/apt/preferences.d/buster-erlang
+
 
 # install Erlang
 RUN set -eux; \
@@ -96,9 +78,9 @@ ENV PATH /usr/lib/rabbitmq/bin:$PATH
 # gpg: key 6026DFCA: public key "RabbitMQ Release Signing Key <info@rabbitmq.com>" imported
 ENV RABBITMQ_GPG_KEY 0A9AF2115F4687BD29803A206B73A36E6026DFCA
 
-ENV RABBITMQ_VERSION 3.7.4
-ENV RABBITMQ_GITHUB_TAG v3.7.4
-ENV RABBITMQ_DEBIAN_VERSION 3.7.4-1
+ENV RABBITMQ_VERSION 3.7.16
+ENV RABBITMQ_GITHUB_TAG v3.7.16
+ENV RABBITMQ_DEBIAN_VERSION 3.7.16-1
 
 RUN set -eux; \
 	\


### PR DESCRIPTION
Hi Usama -

This is mainly me reaching out to you asking to talk about `being less wrong every day`, and utilizing technology to move the needle on world peace. 

This pull request isn't finished - the Dockerfile now builds in the rabbitmq folder, but the container exits after a minute or so. I haven't ever run a microservice, or had multiple dockerized containers interacting - so its all new to me.

I have a consulting company that is building a microservices platform for modeling and coordinating sustainable electrical microgrids. We had a first incarnation as a startup but this time around we are figuring out how to do it open-source and not raising money when we need it. 

I have a prototype working simulation currently all in dotnet that has ostensibly decoupled modules interacting via a local rabbitmq broker. One of my partners (Chris) is a power systems engineers who works in matlab and python. I am currently learning about docker and various other devops tools so that I can have my partners develop with me and also so I can lay the groundwork for bringing additional amazing people onto our team.

The underlying motivation for me is creating a distributed and open-source technology that allows a feasible electrical energy platform for any community with available renewable resources and industry/domestic use that can adjust to stochastic renewable. This should also provide a mechanism to move the high voltages of the grid over to 90% stochastic renewables, but I suspect this will happen second.

You can see a (pretty un-informative from a technology perspective) web-page about us at https://gridworks-consulting.com. Please send me an email or whatsapp at +1-608-609-1289 if you'd be interested in learning more about us by zoom for an hour.
